### PR TITLE
Add support for the real-time events API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,15 @@ OCaml bindings to [Zulip API](https://zulip.com/api/).
         let%lwt mess_id =  Messages.send_message conf dest "New message from `ozulip`" in
         Messages.delete_message mess_id
 ```
+
+### High-level user interaction
+
+```ocaml
+    let _ =
+        let open Ozulip in
+        let conf = init ~domain ~email ~key in
+        Events.interact ~trusted_emails:["you@example.com"] conf (fun msg ->
+            if String.lowercase_ascii msg = "ping"
+            then Lwt.return_some "pong"
+            else Lwt.return_none)
+```

--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,7 @@
   (dune
    (>= 2.0))
   ez_api
+  re
   base64
   lwt
   (ez_file (>= 0.3.0))

--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@
   lwt
   (ez_file (>= 0.3.0))
   cohttp-lwt-unix
-  yojson)
+  yojson
+  logs)
  (tags
   (zulip bindings api)))

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -2,7 +2,6 @@ open Json_encoding
 
 let pp_string fmt = Format.fprintf fmt "\"%s\""
 let pp_int fmt = Format.fprintf fmt "%d"
-let pp_bool fmt = Format.fprintf fmt "%b"
 let pp_sep fmt () = Format.fprintf fmt ", "
 
 let pp_list pp_elt fmt l =

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -2,10 +2,13 @@ open Json_encoding
 
 let pp_string fmt = Format.fprintf fmt "\"%s\""
 let pp_int fmt = Format.fprintf fmt "%d"
+let pp_bool fmt = Format.fprintf fmt "%b"
 let pp_sep fmt () = Format.fprintf fmt ", "
 
 let pp_list pp_elt fmt l =
   Format.fprintf fmt "[%a]" (Format.pp_print_list ~pp_sep pp_elt) l
+let pp_pair pp_l pp_r fmt (l, r) =
+  Format.fprintf fmt "[%a, %a]" pp_l l pp_r r
 
 let pp_int_list = pp_list pp_int
 let pp_string_list = pp_list pp_string

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
  (public_name ozulip)
  (flags :standard -w -27-33)
  (libraries ez_api ez_api.cohttp_lwt ez_api.encoding base64
-            yojson ez_file))
+            yojson ez_file re))

--- a/lib/events.ml
+++ b/lib/events.ml
@@ -1,0 +1,381 @@
+open Common
+open Lwt.Infix
+
+module Smap = Map.Make(String)
+
+module Message = struct
+  type recipients =
+    | Stream of int * string
+    | Private of int list
+
+  type flag =
+    | Read 
+    | Starred
+    | Collapsed
+    | Mentioned
+    | Wildcard_mentioned
+    | Has_alert_word
+    | Historical
+
+  let flag =
+    Json_encoding.(
+      string_enum [
+        "read", Read;
+        "starred", Starred;
+        "collapsed", Collapsed;
+        "mentioned", Mentioned;
+        "wildcard_mentioned", Wildcard_mentioned;
+        "has_alert_word", Has_alert_word;
+        "historical", Historical;
+      ]
+    )
+
+  type t = { 
+    id: int ;
+    sender_id: int ;
+    sender_email: string ;
+    sender_full_name: string;
+    recipients: recipients ;
+    content : string ;
+    flags : flag list ;
+  }
+
+  let content { content; _ } = content
+
+  let sender_mention ?(silent = false) { sender_full_name; sender_id; _ } =
+    Format.asprintf "@%s**%s|%d**" (if silent then "_" else "") sender_full_name sender_id
+
+  let sender_destination { sender_id; _ } = Messages.private_ids [sender_id]
+
+  let destination { recipients; _ } =
+    match recipients with
+    | Stream (stream_id, topic) -> Messages.stream_id stream_id topic
+    | Private ids -> Messages.private_ids ids
+
+  (* Message filters *)
+
+  let is_trusted ?(trusted_ids = []) ?(trusted_emails = []) { sender_id; sender_email; _ } =
+    List.mem sender_id trusted_ids || List.mem sender_email trusted_emails
+
+  let has_flag flag m =
+    if List.mem flag m.flags then true else false
+
+  let is_own_message config m = m.sender_email = config.Config.email
+
+  let is_privmsg { recipients; _ } =
+    (* A message is a privmsg if it has exactly two recipients: us and the
+       sender. *)
+    match recipients with
+    | Private [ _; _ ] -> true
+    | Private _ | Stream _ -> false
+
+  let reply ?(privmsg = false) ?(mention = true) config m =
+    (* Note: the slightly convoluted implementation ensures that we don't keep a
+       reference to [m] in the closure. *)
+    let dest = if privmsg then sender_destination m else destination m in
+    let mention =
+      if privmsg || is_privmsg m || not mention then None 
+      else Some (sender_mention m)
+    in
+    fun reply ->
+      let reply =
+        match mention with
+        | Some mention -> mention ^ " " ^ reply
+        | None -> reply
+      in
+      Messages.send_message config dest reply
+end
+
+type event = ..
+
+type event +=
+  | Message of Message.t
+  | Heartbeat
+  | Other of Json_repr.ezjsonm
+
+type event_type =
+  [ `Message
+  ]
+
+type queue_id = string
+
+type events_queue = {
+  queue_id : queue_id;
+  last_event_id : int;
+  zulip_feature_level : int;
+  event_queue_longpoll_timeout_seconds : int;
+}
+
+let pp_event_type ppf = function
+  | `Message -> Format.fprintf ppf "\"message\""
+  | `EventType et -> Format.fprintf ppf "\"%s\"" (String.escaped et)
+
+let add pp key x args = (key, [ Format.asprintf "%a" pp x ]) :: args
+
+let add_opt pp key opt args =
+  match opt with Some x -> add pp key x args | None -> args
+
+let pp_string ppf s = Format.fprintf ppf "%s" s
+
+let bool_opt = add_opt pp_bool
+let int_opt = add_opt pp_int
+let list_opt pp = add_opt (pp_list pp)
+let list pp = add (pp_list pp)
+let bool = add pp_bool
+let string = add pp_string
+
+let register_result_enc =
+  let open EzEncoding in
+  let open Json_encoding in
+  conv
+    (fun {
+           queue_id;
+           last_event_id;
+           zulip_feature_level;
+           event_queue_longpoll_timeout_seconds;
+         } ->
+      ( queue_id,
+        last_event_id,
+        zulip_feature_level,
+        event_queue_longpoll_timeout_seconds ))
+    (fun ( queue_id,
+           last_event_id,
+           zulip_feature_level,
+           event_queue_longpoll_timeout_seconds ) ->
+      {
+        queue_id;
+        last_event_id;
+        zulip_feature_level;
+        event_queue_longpoll_timeout_seconds;
+      })
+  @@ obj4
+       (req ~description:"The ID of the queue allocated for the client."
+          "queue_id" string)
+       (req
+          ~description:
+            "The initial value of `last_event_id` to pass to `events`."
+          "last_event_id" int)
+       (req ~description:"The server's current Zulip feature level."
+          "zulip_feature_level" int)
+       (dft "event_queue_longpoll_timeout_seconds" int 90)
+
+let request meth config endpoint args =
+  let data = EzAPI.Url.encode_args ~url:true args in
+  Request.request_api config meth endpoint mime_form_url data
+
+let register ?apply_markdown ?client_gravatar ?include_subscribers
+    ?slim_presence ?(event_types = []) ?all_public_streams ?fetch_event_types ?narrow
+    config =
+  let args =
+    bool_opt "apply_markdown" apply_markdown
+    @@ bool_opt "client_gravatar" client_gravatar
+    @@ bool_opt "include_subscribers" include_subscribers
+    @@ bool_opt "slim_presence" slim_presence
+    @@ list pp_event_type "event_types" event_types
+    @@ bool_opt "all_public_streams" all_public_streams
+    @@ list_opt pp_event_type "fetch_event_types" fetch_event_types
+    @@ list_opt (pp_pair pp_string pp_string) "narrow" narrow
+    @@ []
+  in
+
+  let open Lwt_result.Infix in
+  request `POST config "register" args >|= fun s ->
+  Json_encoding.destruct ~ignore_extra_fields:true register_result_enc
+  (EzEncoding.Ezjsonm.from_string s)
+
+let deregister ~queue_id config =
+  let data = EzAPI.Url.encode_args ~url:true (string "queue_id" queue_id []) in
+  Request.request_api config `DELETE "deregister" mime_form_url data >>= function
+  | Ok _ -> Lwt_result.return ()
+  | Error e -> Lwt_result.fail e
+
+module Encodings = struct
+  open Json_encoding
+
+  let message =
+    let open Message in
+    let unexpected what expected =
+      raise (Cannot_destruct ([], Unexpected (what, expected)))
+    in
+    let missing_field key =
+      raise (Cannot_destruct ([], Missing_field key))
+    in
+    let assoc fs key =
+      try Smap.find key fs with Not_found -> missing_field key
+    in
+    let ( |>> ) x f = Json_encoding.destruct ~ignore_extra_fields:true f x in
+    custom
+      ~is_object:true
+      ~schema:Json_schema.any
+      (fun _ -> 
+        failwith "construct: not supported")
+      (function 
+        | `O fs -> 
+          let fs = List.to_seq fs |> Smap.of_seq in
+          let field = assoc fs in
+          let id = field "id" |>> int in
+          let sender_id = field "sender_id" |>> int in
+          let sender_email = field "sender_email" |>> string in
+          let sender_full_name = field "sender_full_name" |>> string in
+          let type_ = field "type" |>> string_enum ["stream", `Stream; "private", `Private] in
+          let recipients =
+            match type_ with
+            | `Stream ->
+              let stream_id = field "stream_id" |>> int in
+              let topic = field "subject" |>> string in
+              Stream (stream_id, topic)
+            | `Private ->
+              let display_recipient = field "display_recipient" |>>
+                list (obj1 (req "id" int)) in
+              Private display_recipient
+          in
+          let content = field "content" |>> string in
+          { id; sender_id; sender_email; sender_full_name; recipients; content; flags = [] }
+        | `Bool _ -> unexpected "boolean" "object"
+        | `Null -> unexpected "null" "object"
+        | `Float _ -> unexpected "float" "object"
+        | `String _ -> unexpected "string" "object"
+        | `A _ -> unexpected "array" "object")
+
+  let message_event =
+    let open Message in
+    conv 
+      (fun message -> ((), message, message.flags))
+      (fun ((), message, flags) -> { message with flags })
+    @@
+    obj3
+      (req "type" (constant "message"))
+      (req "message" message)
+      (req "flags" (list Message.flag))
+
+  let heartbeat_event =
+    obj1 (req "type" (constant "heartbeat"))
+
+  let event =
+    merge_objs (obj1 (req "id" int)) @@
+      union [
+        case message_event (function Message e -> Some e | _ -> None) (fun e -> Message e);
+        case heartbeat_event (function Heartbeat -> Some () | _ -> None) (fun () -> Heartbeat);
+
+        (* It looks like [any_ezjson_object] doesn't actually work with [merge_objs]... *)
+        case any_ezjson_object (function Other e -> Some e | _ -> None) (fun e -> Other e);
+      ]
+
+  let events_response =
+    obj2
+      (req "queue_id" string)
+      (req "events" (list event))
+end
+
+let events ?last_event_id ?(blocking = true) ~queue_id config =
+  let args =
+    int_opt "last_event_id" last_event_id
+    @@ bool "dont_block" (not blocking)
+    @@ string "queue_id" queue_id @@ []
+  in
+
+  let open Lwt_result.Infix in
+  Request.api_get config "events" args >|= fun x ->
+    Format.printf "%s@." x;
+  Json_encoding.destruct ~ignore_extra_fields:true Encodings.events_response
+  (EzEncoding.Ezjsonm.from_string x)
+
+let backoff ?(exp = 2.) ?(ceiling = 10) f x =
+  let rec aux i t =
+    f x >>= function
+    | Ok r -> Lwt.return r
+    | Error _ ->
+      Lwt_unix.sleep t >>= fun () ->
+      if i < ceiling then 
+        aux (i + 1) (exp *. t)
+      else
+        aux i t
+  in aux 0 1.
+
+let stream ?event_types config =
+  let stream, push = Lwt_stream.create () in
+  let register = backoff @@ register ?event_types in
+  (* Repeatedly request events using the provided timeout.
+
+     The timeout returned by [register] is normally higher than the heartbeat
+     frequency of the server, and so we shouldn't hit it unless we get
+     disconnected.
+  *)
+  let rec events' ({ queue_id; last_event_id; _ } as events_config) =
+    let timeout = float_of_int events_config.event_queue_longpoll_timeout_seconds in
+    Lwt.pick [
+      (Lwt_unix.sleep timeout >|= fun () -> None);
+      (events ~last_event_id ~queue_id config >|= fun e -> Some e);
+    ] >>= function
+    | None -> events' events_config
+    | Some e -> Lwt.return e
+  in
+  let rec aux ({ queue_id; last_event_id; _ } as events_config) =
+    events' events_config >>= function
+    | Ok (_, events) -> 
+      let last_event_id =
+      List.fold_left
+        (fun last_id (id, ev) -> 
+          begin match ev with
+          | Heartbeat -> ()
+          | _ -> push (Some ev)
+          end; max id last_id)
+        last_event_id events
+      in
+      aux { events_config with last_event_id }
+    | Error (code, status) ->
+      (* If we get a 4XX HTTP error (client error), we stop trying -- if we are
+         making a bogus query somehow, we probably are going to be stuck in an
+         error loop otherwise.
+       *)
+      if 400 <= code && code < 500 then begin
+        push None;
+        Lwt.fail_with ("HTTP client error " ^ string_of_int code) 
+      end else 
+        (* TODO: only register a new queue if we get a BAD_EVENT_QUEUE_ID error
+           code. 
+         *)
+        register config >>= aux
+  in
+  Lwt.async (fun () -> register config >>= aux);
+  stream
+
+let messages config =
+  Lwt_stream.map (function
+    | Message m -> m
+    | _ -> assert false) @@
+  stream ~event_types:[`Message] config
+let strip_initial_mentions =
+  let re = Re.(Perl.re {|^\s*@\*\*[^\*]+\*\*\s*|} |> compile) in
+  Re.replace_string ~all:true re ~by:""
+
+let commands ?trusted_ids ?trusted_emails ?(strip_mentions = true) config =
+  let is_trusted = 
+    match trusted_ids, trusted_emails with
+    | None, None -> fun _ -> true
+    | _ -> Message.is_trusted ?trusted_ids ?trusted_emails 
+  in
+  messages config |>
+  Lwt_stream.filter_map (fun m -> 
+    if
+      not (Message.is_own_message config m) &&
+      (Message.has_flag Mentioned m || Message.is_privmsg m) &&
+      not (Message.has_flag Read m) &&
+      is_trusted m
+    then
+      let m = if strip_mentions then 
+        { m with content = strip_initial_mentions m.content }
+      else
+        m
+      in
+      Some m
+    else
+      None)
+
+let interact ?trusted_ids ?trusted_emails ?privmsg ?mention config f =
+  commands ?trusted_ids ?trusted_emails config |>
+  Lwt_stream.iter_p (fun m -> 
+    let send = Message.reply ?privmsg ?mention config m in
+    f m.Message.content >>= function
+    | Some reply -> send reply >|= fun _ -> ()
+    | None -> Lwt.return_unit)

--- a/lib/events.ml
+++ b/lib/events.ml
@@ -271,8 +271,7 @@ module Encodings = struct
       ]
 
   let events_response =
-    obj2
-      (req "queue_id" string)
+    obj1
       (req "events" (list event))
 end
 
@@ -321,7 +320,7 @@ let stream ?event_types config =
   in
   let rec aux ({ queue_id; last_event_id; _ } as events_config) =
     events' events_config >>= function
-    | Ok (_, events) -> 
+    | Ok events ->
       let last_event_id =
       List.fold_left
         (fun last_id (id, ev) -> 

--- a/lib/events.ml
+++ b/lib/events.ml
@@ -61,12 +61,22 @@ module Message = struct
 
   let is_own_message config m = m.sender_email = config.Config.email
 
+  let is_selfmsg { recipients; _ } =
+    match recipients with
+    | Private [ _ ] -> true
+    | _ -> false
+
   let is_privmsg { recipients; _ } =
     (* A message is a privmsg if it has exactly two recipients: us and the
        sender. *)
     match recipients with
     | Private [ _; _ ] -> true
     | Private _ | Stream _ -> false
+
+  let is_groupmsg { recipients; _ } =
+    match recipients with
+    | Private [] | Private [ _ ] | Private [ _; _ ] | Stream _ -> false
+    | Private _ -> true
 
   let reply ?(privmsg = false) ?(mention = true) config m =
     (* Note: the slightly convoluted implementation ensures that we don't keep a

--- a/lib/events.ml
+++ b/lib/events.ml
@@ -93,6 +93,9 @@ module Message = struct
         | None -> reply
       in
       Messages.send_message config dest reply
+
+  let replyf ?privmsg ?mention config m =
+    Format.kasprintf (reply ?privmsg ?mention config m)
 end
 
 type event = ..

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -128,6 +128,7 @@ end
     will not block the processing of other commands.
  *)
 val interact :
+    ?switch:Lwt_switch.t ->
     ?trusted_ids:int list ->
     ?trusted_emails:string list ->
     ?privmsg:bool ->
@@ -151,6 +152,7 @@ val interact :
     {!Message.is_trusted}). Otherwise, all messages are kept.
 *)
 val commands :
+      ?switch:Lwt_switch.t ->
       ?trusted_ids:int list ->
       ?trusted_emails:string list ->
       Config.config ->
@@ -163,7 +165,7 @@ val commands :
 
     Bot authors may find {!commands} or {!interact} more useful.
 *)
-val messages : Config.config -> Message.t Lwt_stream.t
+val messages : ?switch:Lwt_switch.t -> Config.config -> Message.t Lwt_stream.t
 
 (** {1:lowlevel Low-Level Interface} *)
 
@@ -255,6 +257,7 @@ val deregister :
     Most of the time, you want to use {!messages} or {!commands} instead.
 *)
 val stream :
+    ?switch:Lwt_switch.t ->
     ?event_types:event_type list ->
     Config.config ->
     event Lwt_stream.t

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -1,0 +1,229 @@
+(**
+
+This module provides both {{!section-highlevel}high-level} and
+{{!section-lowlevel}low-level} interfaces to the real-time events API.
+
+ *)
+
+(** {1:highlevel High-Level Interface} 
+
+ *)
+
+(** The {!module-Message} module represents the content of ["message"] events
+returned by Zulip's real-time events API. *)
+module Message : sig
+  (** Message flags.
+
+      See {: https://zulip.com/api/update-message-flags#available-flags}.
+   *)
+  type flag =
+    | Read 
+    | Starred
+    | Collapsed
+    | Mentioned
+    | Wildcard_mentioned
+    | Has_alert_word
+    | Historical
+
+  (** The type of messages. *)
+  type t
+
+  (** Returns the message's content as a string. *)
+  val content : t -> string
+
+  (** Returns a mention (or silent mention) of the message's sender. *)
+  val sender_mention : ?silent:bool -> t -> string
+
+  (** Returns a {!Messages.destination} for privately replying to the sender. *)
+  val sender_destination : t -> Messages.destination
+
+  (** Returns the message's destination as a {!Messages.destination}. *)
+  val destination : t -> Messages.destination
+
+  (** Tests whether a message has the given message flag. *)
+  val has_flag : flag -> t -> bool
+
+  (** Determines whether a message should be trusted.
+
+    Messages sent by users that are *either* in the [trusted_ids] or
+    [trusted_emails] lists are considered as trusted.
+
+    If none of [trusted_ids] and [trusted_emails] is provided (or if both lists
+    are empty), no message will be trusted.
+   *)
+  val is_trusted :
+    ?trusted_ids:int list -> ?trusted_emails:string list -> t -> bool
+
+  (** Returns whether the message was sent by the current user. *)
+  val is_own_message : Config.config -> t -> bool
+
+  (** Returns whether the message is in a private conversation with a single
+      other user. *)
+  val is_privmsg : t -> bool
+
+  (** Reply to a message. 
+
+      @param privmsg Determines how to reply to commands. By default, replies are
+        sent to the same stream that the command was sent to. If [privmsg] is
+        [true], the replies are always sent as private message to the user
+        initiating the command instead.
+      @param mention By default, a mention of the sender is added to the reply.
+        If [mention] is set false, no such mention will be added. Mentions are
+        never added in private messages.
+  *)
+  val reply :
+    ?privmsg:bool ->
+    ?mention:bool ->
+    Config.config ->
+    t ->
+    string ->
+    (int, int * string option) Lwt_result.t
+end
+
+(** Interact with other users.
+
+    This is a utility function meant for bot authors.
+
+    [interact config f] will call the function [f] on each command received (see
+    {!commands} for details), and replies (see {!Message.reply}) with the result
+    of the call to [f], if any.
+
+    Interactions are parallelized internally, so that a long-running interaction
+    will not block the processing of other commands.
+ *)
+val interact :
+    ?trusted_ids:int list ->
+    ?trusted_emails:string list ->
+    ?privmsg:bool ->
+    ?mention:bool ->
+    Config.config ->
+    (string -> string option Lwt.t) ->
+    unit Lwt.t
+
+(** Returns a stream of the commands sent to the user. 
+
+    This is an utility function meant for bot authors.
+
+    A command is a message:
+     - That was not sent by the current user,
+     - That has not been read yet,
+     - That either was sent in a one-on-one private conversation, or otherwise
+       mentions the current user (through a regular mention, not a wildcard).
+
+    If either [trusted_ids] or [trusted_emails] are provided, this function
+    discards messages that are not trusted (as determined by
+    {!Message.is_trusted}). Otherwise, all messages are kept.
+
+    By default, initial mentions are stripped from the message content for
+    convenience. This behavior can be disabled by setting [strip_mentions] to
+    [false].
+*)
+val commands :
+      ?trusted_ids:int list ->
+      ?trusted_emails:string list ->
+      ?strip_mentions:bool ->
+      Config.config ->
+      Message.t Lwt_stream.t
+
+(** Returns a stream of the message events.
+
+    This stream contains all the messages returned by Zulip, and includes unread
+    messages, and messages sent by the current user.
+
+    Bot authors may find {!commands} or {!interact} more useful.
+*)
+val messages : Config.config -> Message.t Lwt_stream.t
+
+(** {1:lowlevel Low-Level Interface} *)
+
+(** Events returned by the {{: https://zulip.com/api/real-time-events}real-time
+    events API}.
+
+    This is an extensible type to allow supporting additional event types in the
+    future without breaking backwards compatibility.
+ *)
+type event = ..
+
+type event +=
+  | Message of Message.t
+    (** A message that was sent to the user. *)
+  | Heartbeat
+    (** Heartbeat events sent by Zulip to keep the connection alive. 
+
+        These should only be relevant to users of the low-level {!events}
+        interface. High-level interfaces such as {!stream} automatically deals
+        with heartbeat events for you.
+     *)
+
+(** The event types that can be filtered in calls to {!register}. *)
+type event_type = [ `Message ]
+
+(** A queue identifier is really just a string, but we wrap it in a private type
+    for clarity. 
+ *)
+type queue_id = private string
+
+(** Event queue configuration.
+
+    This is the type returned by {{: https://zulip.com/api/register-queue}the
+    ["register"] endpoint}.
+ *)
+type events_queue = {
+  queue_id : queue_id;
+  last_event_id : int;
+  zulip_feature_level : int;
+  event_queue_longpoll_timeout_seconds : int;
+}
+
+(** Low-level wrapper around the ["register"] endpoint.
+
+    See the {{: https://zulip.com/api/register-queue}Zulip documentation} for
+    more details.
+ *)
+val register :
+    ?apply_markdown:bool ->
+    ?client_gravatar:bool ->
+    ?include_subscribers:bool ->
+    ?slim_presence:bool ->
+    ?event_types:[< event_type as 'a ] list ->
+    ?all_public_streams:bool ->
+    ?fetch_event_types:'a list ->
+    ?narrow:(string * string) list ->
+    Config.config ->
+    (events_queue, int * string option) Lwt_result.t
+
+(** Low-level wrapper around the ["events"] endpoint.
+
+    See the {{: https://zulip.com/api/get-events}Zulip documentation} for more
+    details.
+ *)
+val events :
+    ?last_event_id:int ->
+    ?blocking:bool ->
+    queue_id:queue_id ->
+    Config.config ->
+    (queue_id * (int * event) list, int * string option) Lwt_result.t
+
+(** Low-level wrapper around the ["deregister"] endpoint.
+
+    See the {{: https://zulip.com/api/delete-queue}Zulip documentation} for more
+    details.
+ *)
+val deregister : 
+    queue_id:string ->
+    Config.config ->
+    (unit, int * string option) Lwt_result.t
+
+(** Returns a stream of events sent by the Zulip API.
+
+    This is a wrapper around the low-level {!register} and {!events} function
+    that takes care of dealing with reconnections, queue management, and
+    heartbeats automatically (in particular, the returned stream will never
+    contain a {!Heartbeat} event).
+
+    Most of the time, you want to use {!messages} or {!commands} instead.
+*)
+val stream :
+    ?event_types:event_type list ->
+    Config.config ->
+    event Lwt_stream.t

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -100,6 +100,20 @@ module Message : sig
     t ->
     string ->
     (int, int * string option) Lwt_result.t
+
+  (** [replyf] calls [reply] with a pretty-printed string argument.
+
+      [replyf conf msg "Here is a quote: %s" quote] does the same thing as
+      [reply conf msg (Format.asprintf "Here is a quote: %s" quote)] but is
+      more convenient.
+  *)
+  val replyf:
+    ?privmsg:bool ->
+    ?mention:bool ->
+    Config.config ->
+    t ->
+    ('a, Format.formatter, unit, (int, int * string option) Lwt_result.t) format4 ->
+    'a
 end
 
 (** Interact with other users.

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -5,7 +5,7 @@ This module provides both {{!section-highlevel}high-level} and
 
  *)
 
-(** {1:highlevel High-Level Interface} 
+(** {1:highlevel High-Level Interface}
 
  *)
 
@@ -17,7 +17,7 @@ module Message : sig
       See {: https://zulip.com/api/update-message-flags#available-flags}.
    *)
   type flag =
-    | Read 
+    | Read
     | Starred
     | Collapsed
     | Mentioned
@@ -83,7 +83,7 @@ module Message : sig
    *)
   val is_groupmsg : t -> bool
 
-  (** Reply to a message. 
+  (** Reply to a message.
 
       @param privmsg Determines how to reply to commands. By default, replies are
         sent to the same stream that the command was sent to. If [privmsg] is
@@ -136,28 +136,23 @@ val interact :
     (string -> string option Lwt.t) ->
     unit Lwt.t
 
-(** Returns a stream of the commands sent to the user. 
+(** Returns a stream of the commands sent to the user.
 
     This is an utility function meant for bot authors.
 
     A command is a message:
      - That was not sent by the current user,
      - That has not been read yet,
-     - That either was sent in a one-on-one private conversation, or otherwise
-       mentions the current user (through a regular mention, not a wildcard).
+     - That either was sent in a one-on-one private conversation, or starts by a
+       mention of the current user (must be a regular mention, not a wildcard).
 
     If either [trusted_ids] or [trusted_emails] are provided, this function
     discards messages that are not trusted (as determined by
     {!Message.is_trusted}). Otherwise, all messages are kept.
-
-    By default, initial mentions are stripped from the message content for
-    convenience. This behavior can be disabled by setting [strip_mentions] to
-    [false].
 *)
 val commands :
       ?trusted_ids:int list ->
       ?trusted_emails:string list ->
-      ?strip_mentions:bool ->
       Config.config ->
       Message.t Lwt_stream.t
 
@@ -184,7 +179,7 @@ type event +=
   | Message of Message.t
     (** A message that was sent to the user. *)
   | Heartbeat
-    (** Heartbeat events sent by Zulip to keep the connection alive. 
+    (** Heartbeat events sent by Zulip to keep the connection alive.
 
         These should only be relevant to users of the low-level {!events}
         interface. High-level interfaces such as {!stream} automatically deals
@@ -195,7 +190,7 @@ type event +=
 type event_type = [ `Message ]
 
 (** A queue identifier is really just a string, but we wrap it in a private type
-    for clarity. 
+    for clarity.
  *)
 type queue_id = private string
 
@@ -245,7 +240,7 @@ val events :
     See the {{: https://zulip.com/api/delete-queue}Zulip documentation} for more
     details.
  *)
-val deregister : 
+val deregister :
     queue_id:string ->
     Config.config ->
     (unit, int * string option) Lwt_result.t

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -25,8 +25,23 @@ module Message : sig
     | Has_alert_word
     | Historical
 
+  (** Message recipients *)
+  type recipients =
+    | Stream of int * string
+      (** [Stream (stream_id, topic)] *)
+    | Private of int list
+      (** [Private user_ids] *)
+
   (** The type of messages. *)
-  type t
+  type t = private {
+    id: int ;
+    sender_id: int ;
+    sender_email: string ;
+    sender_full_name: string;
+    recipients: recipients ;
+    content : string ;
+    flags : flag list ;
+  }
 
   (** Returns the message's content as a string. *)
   val content : t -> string

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -57,14 +57,31 @@ module Message : sig
   (** Returns whether the message was sent by the current user. *)
   val is_own_message : Config.config -> t -> bool
 
-  (** Returns whether the message is in a private conversation with a single
-      other user.
+  (** Returns whether the message is a self-message, i.e. a message in a
+      conversation between the current user and themselves.
+
+      Note that this is different from [is_own_message]: all "selfmsg" are sent
+      by the current user (i.e. [is_own_message] is [true]), but the current
+      user can send messages in conversations involving other users (in which
+      case [is_own_message] would be [true] but [is_selfmsg] would be [false]).
+   *)
+  val is_selfmsg : t -> bool
+
+  (** Returns whether the message is in a private conversation with exactly two
+      users.
 
       Note that what OZulip calls a "privmsg" here is not the same as what Zulip
       calls a "private" message, because Zulip's "private" message can also be
       group conversations with many users.
    *)
   val is_privmsg : t -> bool
+
+  (** Returns whether the message is in a private *group* conversation.
+
+      Messages sent to a stream are never "groupmsg", and neither are private
+      messages with two members or less.
+   *)
+  val is_groupmsg : t -> bool
 
   (** Reply to a message. 
 

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -224,7 +224,7 @@ val events :
     ?blocking:bool ->
     queue_id:queue_id ->
     Config.config ->
-    (queue_id * (int * event) list, int * string option) Lwt_result.t
+    ((int * event) list, int * string option) Lwt_result.t
 
 (** Low-level wrapper around the ["deregister"] endpoint.
 

--- a/lib/events.mli
+++ b/lib/events.mli
@@ -58,7 +58,12 @@ module Message : sig
   val is_own_message : Config.config -> t -> bool
 
   (** Returns whether the message is in a private conversation with a single
-      other user. *)
+      other user.
+
+      Note that what OZulip calls a "privmsg" here is not the same as what Zulip
+      calls a "private" message, because Zulip's "private" message can also be
+      group conversations with many users.
+   *)
   val is_privmsg : t -> bool
 
   (** Reply to a message. 

--- a/lib/ozulip.ml
+++ b/lib/ozulip.ml
@@ -1,6 +1,10 @@
 (** Message requests *)
 module Messages = Messages
 
+(** The {!Events} module provides an interface to Zulip's {{:
+https://zulip.com/api/real-time-events}real-time events API}. *)
+module Events = Events
+
 (** [init domain email key] initialises connection config with the Zulip server
     with [domain] as domain name, [email] as user's mail and [key] as user's API key *)
 let init ~domain ~email ~key : Config.config =

--- a/lib/request.ml
+++ b/lib/request.ml
@@ -5,14 +5,22 @@ let get_url config endpoint = Format.sprintf "%s/%s" config.url endpoint
 let get_auth_token config =
   Base64.encode_string @@ Format.sprintf "%s:%s" config.email config.key
 
+let get_auth_headers config =
+  let auth = get_auth_token config in
+  [ ("Authorization", "Basic " ^ auth) ]
+
+let api_get config endpoint content =
+  let url = get_url config endpoint in
+  let headers = get_auth_headers config in
+  let content = EzAPI.Url.encode_args ~url:true content in
+  EzCohttp_lwt.get ~meth:`GET ~headers (URL (url ^ "?" ^ content))
+
 let request_api config meth endpoint content_type content =
   let url = get_url config endpoint in
-  let auth = get_auth_token config in
-  let headers = [ ("Authorization", "Basic " ^ auth) ] in
+  let headers = get_auth_headers config in
   EzCohttp_lwt.post ~meth ~content_type ~headers ~content (URL url)
 
 let request_api_no_body config meth endpoint =
   let url = get_url config endpoint in
-  let auth = get_auth_token config in
-  let headers = [ ("Authorization", "Basic " ^ auth) ] in
+  let headers = get_auth_headers config in
   EzCohttp_lwt.post ~meth ~headers (URL url)

--- a/ozulip.opam
+++ b/ozulip.opam
@@ -12,6 +12,7 @@ depends: [
   "ocaml" {>= "4.10"}
   "dune" {>= "2.0"}
   "ez_api"
+  "re"
   "base64"
   "lwt"
   "ez_file" {>= "0.3.0"}

--- a/ozulip.opam
+++ b/ozulip.opam
@@ -18,6 +18,7 @@ depends: [
   "ez_file" {>= "0.3.0"}
   "cohttp-lwt-unix"
   "yojson"
+  "logs"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
Zulip's real-time events API [1] allows registering to a stream of events that occur on the server in real-time. The most useful of these events are "message" events, that are fired when a new message is seen by the user.

This PR adds support for the real-time events API in OZulip through the new [Events] module, whose interface is thoroughly documented in the PR.

The most convenient function in the [Events] module is [interact], which evaluates a Lwt thread in response to messages from trusted senders that mention the current user, and sends the resulting of evaluating the thread as a reply to the original message.

[1]: https://zulip.com/api/real-time-events